### PR TITLE
Add a new `Interval` class based on the SDK `Bounds`

### DIFF
--- a/src/frequenz/core/collections.py
+++ b/src/frequenz/core/collections.py
@@ -1,0 +1,55 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Data structures that contain collections of values or objects."""
+
+from dataclasses import dataclass
+from typing import Any, Generic, Protocol, TypeVar, cast
+
+
+class Comparable(Protocol):
+    """A protocol that requires the implementation of comparison methods.
+
+    This protocol is used to ensure that types can be compared using
+    the less than or equal to (`<=`) and greater than or equal to (`>=`)
+    operators.
+    """
+
+    def __le__(self, other: Any, /) -> bool:
+        """Return whether this instance is less than or equal to `other`."""
+
+    def __ge__(self, other: Any, /) -> bool:
+        """Return whether this instance is greater than or equal to `other`."""
+
+
+_T = TypeVar("_T", bound=Comparable | None)
+
+
+@dataclass(frozen=True)
+class Bounds(Generic[_T]):
+    """Lower and upper bound values."""
+
+    lower: _T
+    """Lower bound."""
+
+    upper: _T
+    """Upper bound."""
+
+    def __contains__(self, item: _T) -> bool:
+        """
+        Check if the value is within the range of the container.
+
+        Args:
+            item: The value to check.
+
+        Returns:
+            bool: True if value is within the range, otherwise False.
+        """
+        if self.lower is None and self.upper is None:
+            return True
+        if self.lower is None:
+            return item <= self.upper
+        if self.upper is None:
+            return self.lower <= item
+
+        return cast(Comparable, self.lower) <= item <= cast(Comparable, self.upper)

--- a/src/frequenz/core/collections.py
+++ b/src/frequenz/core/collections.py
@@ -27,6 +27,11 @@ class Interval(Generic[LessThanComparableOrNoneT]):
     The `start` and `end` are inclusive, meaning that the `start` and `end` limites are
     included in the range when checking if a value is contained by the interval.
 
+    If the `start` or `end` is `None`, it means that the interval is unbounded in that
+    direction.
+
+    If `start` is bigger than `end`, a `ValueError` is raised.
+
     The type stored in the interval must be comparable, meaning that it must implement
     the `__lt__` method to be able to compare values.
     """
@@ -36,6 +41,17 @@ class Interval(Generic[LessThanComparableOrNoneT]):
 
     end: LessThanComparableOrNoneT
     """The end of the interval."""
+
+    def __post_init__(self) -> None:
+        """Check if the start is less than or equal to the end."""
+        if self.start is None or self.end is None:
+            return
+        start = cast(LessThanComparable, self.start)
+        end = cast(LessThanComparable, self.end)
+        if start > end:
+            raise ValueError(
+                f"The start ({self.start}) can't be bigger than end ({self.end})"
+            )
 
     def __contains__(self, item: LessThanComparableOrNoneT) -> bool:
         """

--- a/src/frequenz/core/collections.py
+++ b/src/frequenz/core/collections.py
@@ -22,20 +22,21 @@ class Comparable(Protocol):
         """Return whether this instance is greater than or equal to `other`."""
 
 
-_T = TypeVar("_T", bound=Comparable | None)
+ComparableOrNoneT = TypeVar("ComparableOrNoneT", bound=Comparable | None)
+"""Type variable for values that are comparable or `None`."""
 
 
 @dataclass(frozen=True)
-class Bounds(Generic[_T]):
+class Bounds(Generic[ComparableOrNoneT]):
     """Lower and upper bound values."""
 
-    lower: _T
+    lower: ComparableOrNoneT
     """Lower bound."""
 
-    upper: _T
+    upper: ComparableOrNoneT
     """Upper bound."""
 
-    def __contains__(self, item: _T) -> bool:
+    def __contains__(self, item: ComparableOrNoneT) -> bool:
         """
         Check if the value is within the range of the container.
 

--- a/src/frequenz/core/collections.py
+++ b/src/frequenz/core/collections.py
@@ -21,21 +21,21 @@ LessThanComparableOrNoneT = TypeVar(
 
 
 @dataclass(frozen=True)
-class Bounds(Generic[LessThanComparableOrNoneT]):
-    """A range of values with lower and upper bounds.
+class Interval(Generic[LessThanComparableOrNoneT]):
+    """An interval to test if a value is within its limits.
 
-    The bounds are inclusive, meaning that the lower and upper bounds are included in
-    the range when checking if a value is within the range.
+    The `start` and `end` are inclusive, meaning that the `start` and `end` limites are
+    included in the range when checking if a value is contained by the interval.
 
-    The type stored in the bounds must be comparable, meaning that it must implement the
-    `__lt__` method to be able to compare values.
+    The type stored in the interval must be comparable, meaning that it must implement
+    the `__lt__` method to be able to compare values.
     """
 
-    lower: LessThanComparableOrNoneT
-    """Lower bound."""
+    start: LessThanComparableOrNoneT
+    """The start of the interval."""
 
-    upper: LessThanComparableOrNoneT
-    """Upper bound."""
+    end: LessThanComparableOrNoneT
+    """The end of the interval."""
 
     def __contains__(self, item: LessThanComparableOrNoneT) -> bool:
         """
@@ -51,20 +51,20 @@ class Bounds(Generic[LessThanComparableOrNoneT]):
             return False
         casted_item = cast(LessThanComparable, item)
 
-        if self.lower is None and self.upper is None:
+        if self.start is None and self.end is None:
             return True
-        if self.lower is None:
-            upper = cast(LessThanComparable, self.upper)
-            return not casted_item > upper
-        if self.upper is None:
-            return not self.lower > item
-        # mypy seems to get confused here, not being able to narrow upper and lower to
+        if self.start is None:
+            start = cast(LessThanComparable, self.end)
+            return not casted_item > start
+        if self.end is None:
+            return not self.start > item
+        # mypy seems to get confused here, not being able to narrow start and end to
         # just LessThanComparable, complaining with:
         #   error: Unsupported left operand type for <= (some union)
         # But we know if they are not None, they should be LessThanComparable, and
         # actually mypy is being able to figure it out in the lines above, just not in
         # this one, so it should be safe to cast.
         return not (
-            casted_item < cast(LessThanComparable, self.lower)
-            or casted_item > cast(LessThanComparable, self.upper)
+            casted_item < cast(LessThanComparable, self.start)
+            or casted_item > cast(LessThanComparable, self.end)
         )

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -8,7 +8,7 @@ from typing import Self
 
 import pytest
 
-from frequenz.core.collections import Bounds, LessThanComparable
+from frequenz.core.collections import Interval, LessThanComparable
 
 
 class CustomComparable:
@@ -34,7 +34,7 @@ class CustomComparable:
 
 
 @pytest.mark.parametrize(
-    "lower, upper, within, at_lower, at_upper, below_lower, above_upper",
+    "start, end, within, at_start, at_end, before_start, after_end",
     [
         (10.0, 100.0, 50.0, 10.0, 100.0, 9.0, 101.0),
         (
@@ -48,26 +48,26 @@ class CustomComparable:
         ),
     ],
 )
-def test_bounds_contains(  # pylint: disable=too-many-arguments
-    lower: LessThanComparable,
-    upper: LessThanComparable,
+def test_interval_contains(  # pylint: disable=too-many-arguments
+    start: LessThanComparable,
+    end: LessThanComparable,
     within: LessThanComparable,
-    at_lower: LessThanComparable,
-    at_upper: LessThanComparable,
-    below_lower: LessThanComparable,
-    above_upper: LessThanComparable,
+    at_start: LessThanComparable,
+    at_end: LessThanComparable,
+    before_start: LessThanComparable,
+    after_end: LessThanComparable,
 ) -> None:
-    """Test if a value is within the bounds."""
-    bounds = Bounds(lower=lower, upper=upper)
-    assert within in bounds  # within
-    assert at_lower in bounds  # at lower
-    assert at_upper in bounds  # at upper
-    assert below_lower not in bounds  # below lower
-    assert above_upper not in bounds  # above upper
+    """Test if a value is within the interval."""
+    interval = Interval(start=start, end=end)
+    assert within in interval  # within
+    assert at_start in interval  # at start
+    assert at_end in interval  # at end
+    assert before_start not in interval  # before start
+    assert after_end not in interval  # after end
 
 
 @pytest.mark.parametrize(
-    "upper, within, at_upper, above_upper",
+    "end, within, at_end, after_end",
     [
         (100.0, 50.0, 100.0, 101.0),
         (
@@ -78,21 +78,21 @@ def test_bounds_contains(  # pylint: disable=too-many-arguments
         ),
     ],
 )
-def test_bounds_contains_no_lower(
-    upper: LessThanComparable,
+def test_interval_contains_no_start(
+    end: LessThanComparable,
     within: LessThanComparable,
-    at_upper: LessThanComparable,
-    above_upper: LessThanComparable,
+    at_end: LessThanComparable,
+    after_end: LessThanComparable,
 ) -> None:
-    """Test if a value is within the bounds with no lower bound."""
-    bounds_no_lower = Bounds(lower=None, upper=upper)
-    assert within in bounds_no_lower  # within upper
-    assert at_upper in bounds_no_lower  # at upper
-    assert above_upper not in bounds_no_lower  # above upper
+    """Test if a value is within the interval with no start."""
+    interval_no_start = Interval(start=None, end=end)
+    assert within in interval_no_start  # within end
+    assert at_end in interval_no_start  # at end
+    assert after_end not in interval_no_start  # after end
 
 
 @pytest.mark.parametrize(
-    "lower, within, at_lower, below_lower",
+    "start, within, at_start, before_start",
     [
         (10.0, 50.0, 10.0, 9.0),
         (
@@ -103,17 +103,17 @@ def test_bounds_contains_no_lower(
         ),
     ],
 )
-def test_bounds_contains_no_upper(
-    lower: LessThanComparable,
+def test_interval_contains_no_end(
+    start: LessThanComparable,
     within: LessThanComparable,
-    at_lower: LessThanComparable,
-    below_lower: LessThanComparable,
+    at_start: LessThanComparable,
+    before_start: LessThanComparable,
 ) -> None:
-    """Test if a value is within the bounds with no upper bound."""
-    bounds_no_upper = Bounds(lower=lower, upper=None)
-    assert within in bounds_no_upper  # within lower
-    assert at_lower in bounds_no_upper  # at lower
-    assert below_lower not in bounds_no_upper  # below lower
+    """Test if a value is within the interval with no end."""
+    interval_no_end = Interval(start=start, end=None)
+    assert within in interval_no_end  # within start
+    assert at_start in interval_no_end  # at start
+    assert before_start not in interval_no_end  # before start
 
 
 @pytest.mark.parametrize(
@@ -127,7 +127,9 @@ def test_bounds_contains_no_upper(
         CustomComparable(-10),
     ],
 )
-def test_bounds_contains_no_bounds(value: LessThanComparable) -> None:
-    """Test if a value is within the bounds with no bounds."""
-    bounds_no_bounds: Bounds[LessThanComparable | None] = Bounds(lower=None, upper=None)
-    assert value in bounds_no_bounds  # any value within bounds
+def test_interval_contains_unbound(value: LessThanComparable) -> None:
+    """Test if a value is within the interval with no bounds."""
+    interval_no_bounds: Interval[LessThanComparable | None] = Interval(
+        start=None, end=None
+    )
+    assert value in interval_no_bounds  # any value within bounds

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -34,6 +34,22 @@ class CustomComparable:
 
 
 @pytest.mark.parametrize(
+    "start, end",
+    [
+        (10.0, -100.0),
+        (CustomComparable(10), CustomComparable(-100)),
+    ],
+)
+def test_invalid_range(start: LessThanComparable, end: LessThanComparable) -> None:
+    """Test if the interval has an invalid range."""
+    with pytest.raises(
+        ValueError,
+        match=rf"The start \({start}\) can't be bigger than end \({end}\)",
+    ):
+        Interval(start, end)
+
+
+@pytest.mark.parametrize(
     "start, end, within, at_start, at_end, before_start, after_end",
     [
         (10.0, 100.0, 50.0, 10.0, 100.0, 9.0, 101.0),

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -4,39 +4,36 @@
 """Tests for the collections module."""
 
 
-from datetime import datetime
-
-from frequenz.sdk.timeseries._base_types import Bounds, SystemBounds
-from frequenz.sdk.timeseries._quantities import Power
+from frequenz.core.collections import Bounds
 
 
 def test_bounds_contains() -> None:
     """Tests with complete bounds."""
-    bounds = Bounds(lower=Power.from_watts(10), upper=Power.from_watts(100))
-    assert Power.from_watts(50) in bounds  # within
-    assert Power.from_watts(10) in bounds  # at lower
-    assert Power.from_watts(100) in bounds  # at upper
-    assert Power.from_watts(9) not in bounds  # below lower
-    assert Power.from_watts(101) not in bounds  # above upper
+    bounds = Bounds(lower=10.0, upper=100.0)
+    assert 50.0 in bounds  # within
+    assert 10.0 in bounds  # at lower
+    assert 100.0 in bounds  # at upper
+    assert 9.0 not in bounds  # below lower
+    assert 101.0 not in bounds  # above upper
 
 
 def test_bounds_contains_no_lower() -> None:
     """Tests without lower bound."""
-    bounds_no_lower = Bounds(lower=None, upper=Power.from_watts(100))
-    assert Power.from_watts(50) in bounds_no_lower  # within upper
-    assert Power.from_watts(100) in bounds_no_lower  # at upper
-    assert Power.from_watts(101) not in bounds_no_lower  # above upper
+    bounds_no_lower = Bounds(lower=None, upper=100.0)
+    assert 50.0 in bounds_no_lower  # within upper
+    assert 100.0 in bounds_no_lower  # at upper
+    assert 101.0 not in bounds_no_lower  # above upper
 
 
 def test_bounds_contains_no_upper() -> None:
     """Tests without upper bound."""
-    bounds_no_upper = Bounds(lower=Power.from_watts(10), upper=None)
-    assert Power.from_watts(50) in bounds_no_upper  # within lower
-    assert Power.from_watts(10) in bounds_no_upper  # at lower
-    assert Power.from_watts(9) not in bounds_no_upper  # below lower
+    bounds_no_upper = Bounds(lower=10.0, upper=None)
+    assert 50.0 in bounds_no_upper  # within lower
+    assert 10.0 in bounds_no_upper  # at lower
+    assert 9.0 not in bounds_no_upper  # below lower
 
 
 def test_bounds_contains_no_bounds() -> None:
     """Tests with no bounds."""
-    bounds_no_bounds: Bounds[Power | None] = Bounds(lower=None, upper=None)
-    assert Power.from_watts(50) in bounds_no_bounds  # any value within bounds
+    bounds_no_bounds: Bounds[float | None] = Bounds(lower=None, upper=None)
+    assert 50.0 in bounds_no_bounds  # any value within bounds

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,0 +1,42 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the collections module."""
+
+
+from datetime import datetime
+
+from frequenz.sdk.timeseries._base_types import Bounds, SystemBounds
+from frequenz.sdk.timeseries._quantities import Power
+
+
+def test_bounds_contains() -> None:
+    """Tests with complete bounds."""
+    bounds = Bounds(lower=Power.from_watts(10), upper=Power.from_watts(100))
+    assert Power.from_watts(50) in bounds  # within
+    assert Power.from_watts(10) in bounds  # at lower
+    assert Power.from_watts(100) in bounds  # at upper
+    assert Power.from_watts(9) not in bounds  # below lower
+    assert Power.from_watts(101) not in bounds  # above upper
+
+
+def test_bounds_contains_no_lower() -> None:
+    """Tests without lower bound."""
+    bounds_no_lower = Bounds(lower=None, upper=Power.from_watts(100))
+    assert Power.from_watts(50) in bounds_no_lower  # within upper
+    assert Power.from_watts(100) in bounds_no_lower  # at upper
+    assert Power.from_watts(101) not in bounds_no_lower  # above upper
+
+
+def test_bounds_contains_no_upper() -> None:
+    """Tests without upper bound."""
+    bounds_no_upper = Bounds(lower=Power.from_watts(10), upper=None)
+    assert Power.from_watts(50) in bounds_no_upper  # within lower
+    assert Power.from_watts(10) in bounds_no_upper  # at lower
+    assert Power.from_watts(9) not in bounds_no_upper  # below lower
+
+
+def test_bounds_contains_no_bounds() -> None:
+    """Tests with no bounds."""
+    bounds_no_bounds: Bounds[Power | None] = Bounds(lower=None, upper=None)
+    assert Power.from_watts(50) in bounds_no_bounds  # any value within bounds

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -4,36 +4,130 @@
 """Tests for the collections module."""
 
 
-from frequenz.core.collections import Bounds
+from typing import Self
+
+import pytest
+
+from frequenz.core.collections import Bounds, LessThanComparable
 
 
-def test_bounds_contains() -> None:
-    """Tests with complete bounds."""
-    bounds = Bounds(lower=10.0, upper=100.0)
-    assert 50.0 in bounds  # within
-    assert 10.0 in bounds  # at lower
-    assert 100.0 in bounds  # at upper
-    assert 9.0 not in bounds  # below lower
-    assert 101.0 not in bounds  # above upper
+class CustomComparable:
+    """A custom comparable class."""
+
+    def __init__(self, value: int) -> None:
+        """Initialize this instance."""
+        self.value = value
+
+    def __lt__(self, other: Self) -> bool:
+        """Return whether this instance is less than other."""
+        return self.value < other.value
+
+    def __eq__(self, other: object) -> bool:
+        """Return whether this instance is equal to other."""
+        if not isinstance(other, CustomComparable):
+            return False
+        return self.value == other.value
+
+    def __repr__(self) -> str:
+        """Return a string representation of this instance."""
+        return str(self.value)
 
 
-def test_bounds_contains_no_lower() -> None:
-    """Tests without lower bound."""
-    bounds_no_lower = Bounds(lower=None, upper=100.0)
-    assert 50.0 in bounds_no_lower  # within upper
-    assert 100.0 in bounds_no_lower  # at upper
-    assert 101.0 not in bounds_no_lower  # above upper
+@pytest.mark.parametrize(
+    "lower, upper, within, at_lower, at_upper, below_lower, above_upper",
+    [
+        (10.0, 100.0, 50.0, 10.0, 100.0, 9.0, 101.0),
+        (
+            CustomComparable(10),
+            CustomComparable(100),
+            CustomComparable(50),
+            CustomComparable(10),
+            CustomComparable(100),
+            CustomComparable(9),
+            CustomComparable(101),
+        ),
+    ],
+)
+def test_bounds_contains(  # pylint: disable=too-many-arguments
+    lower: LessThanComparable,
+    upper: LessThanComparable,
+    within: LessThanComparable,
+    at_lower: LessThanComparable,
+    at_upper: LessThanComparable,
+    below_lower: LessThanComparable,
+    above_upper: LessThanComparable,
+) -> None:
+    """Test if a value is within the bounds."""
+    bounds = Bounds(lower=lower, upper=upper)
+    assert within in bounds  # within
+    assert at_lower in bounds  # at lower
+    assert at_upper in bounds  # at upper
+    assert below_lower not in bounds  # below lower
+    assert above_upper not in bounds  # above upper
 
 
-def test_bounds_contains_no_upper() -> None:
-    """Tests without upper bound."""
-    bounds_no_upper = Bounds(lower=10.0, upper=None)
-    assert 50.0 in bounds_no_upper  # within lower
-    assert 10.0 in bounds_no_upper  # at lower
-    assert 9.0 not in bounds_no_upper  # below lower
+@pytest.mark.parametrize(
+    "upper, within, at_upper, above_upper",
+    [
+        (100.0, 50.0, 100.0, 101.0),
+        (
+            CustomComparable(100),
+            CustomComparable(50),
+            CustomComparable(100),
+            CustomComparable(101),
+        ),
+    ],
+)
+def test_bounds_contains_no_lower(
+    upper: LessThanComparable,
+    within: LessThanComparable,
+    at_upper: LessThanComparable,
+    above_upper: LessThanComparable,
+) -> None:
+    """Test if a value is within the bounds with no lower bound."""
+    bounds_no_lower = Bounds(lower=None, upper=upper)
+    assert within in bounds_no_lower  # within upper
+    assert at_upper in bounds_no_lower  # at upper
+    assert above_upper not in bounds_no_lower  # above upper
 
 
-def test_bounds_contains_no_bounds() -> None:
-    """Tests with no bounds."""
-    bounds_no_bounds: Bounds[float | None] = Bounds(lower=None, upper=None)
-    assert 50.0 in bounds_no_bounds  # any value within bounds
+@pytest.mark.parametrize(
+    "lower, within, at_lower, below_lower",
+    [
+        (10.0, 50.0, 10.0, 9.0),
+        (
+            CustomComparable(10),
+            CustomComparable(50),
+            CustomComparable(10),
+            CustomComparable(9),
+        ),
+    ],
+)
+def test_bounds_contains_no_upper(
+    lower: LessThanComparable,
+    within: LessThanComparable,
+    at_lower: LessThanComparable,
+    below_lower: LessThanComparable,
+) -> None:
+    """Test if a value is within the bounds with no upper bound."""
+    bounds_no_upper = Bounds(lower=lower, upper=None)
+    assert within in bounds_no_upper  # within lower
+    assert at_lower in bounds_no_upper  # at lower
+    assert below_lower not in bounds_no_upper  # below lower
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        50.0,
+        10.0,
+        -10.0,
+        CustomComparable(50),
+        CustomComparable(10),
+        CustomComparable(-10),
+    ],
+)
+def test_bounds_contains_no_bounds(value: LessThanComparable) -> None:
+    """Test if a value is within the bounds with no bounds."""
+    bounds_no_bounds: Bounds[LessThanComparable | None] = Bounds(lower=None, upper=None)
+    assert value in bounds_no_bounds  # any value within bounds


### PR DESCRIPTION
This new class is based on the SDK `Bounds` class. It is renamed to `Interval` partly because this is a more generic repo and this is a more generic name, but also because we will add `Bounds` class in the future to represent multiple (inclusion) intervals, which is how the new microgrid API handle bounds.

Fixes #11, #12, #13, #15.