### PR TITLE
Revamp `BackgroundService` and rename to `Service`

### DIFF
--- a/src/frequenz/core/asyncio.py
+++ b/src/frequenz/core/asyncio.py
@@ -401,7 +401,7 @@ class ServiceBase(Service, abc.ABC):
             return
         self.cancel(msg)
         try:
-            await self.wait()
+            await self
         except BaseExceptionGroup as exc_group:
             # We want to ignore CancelledError here as we explicitly cancelled all the
             # tasks.
@@ -441,7 +441,7 @@ class ServiceBase(Service, abc.ABC):
         """
         await self.stop()
 
-    async def wait(self) -> None:
+    async def _wait(self) -> None:
         """Wait for this service to finish.
 
         Wait until all the service tasks are finished.
@@ -483,7 +483,7 @@ class ServiceBase(Service, abc.ABC):
         Returns:
             An implementation-specific generator for the awaitable.
         """
-        return self.wait().__await__()
+        return self._wait().__await__()
 
     def __del__(self) -> None:
         """Destroy this instance.

--- a/src/frequenz/core/asyncio.py
+++ b/src/frequenz/core/asyncio.py
@@ -12,14 +12,51 @@ The module provides the following classes and functions:
   task and waits for it to finish, handling `CancelledError` exceptions.
 - [Service][frequenz.core.asyncio.Service]: A base class for
   implementing services running in the background that can be started and stopped.
+- [TaskCreator][frequenz.core.asyncio.TaskCreator]: A protocol for creating tasks.
 """
 
 
 import abc
 import asyncio
 import collections.abc
+import contextvars
 from types import TracebackType
-from typing import Any, Self
+from typing import Any, Protocol, Self, TypeVar, runtime_checkable
+
+TaskReturnT = TypeVar("TaskReturnT")
+"""The type of the return value of a task."""
+
+
+@runtime_checkable
+class TaskCreator(Protocol):
+    """A protocol for creating tasks.
+
+    Built-in asyncio functions and classes implementing this protocol:
+
+    - [`asyncio`][]
+    - [`asyncio.AbstractEventLoop`][] (returned by [`asyncio.get_event_loop`][] for
+      example)
+    - [`asyncio.TaskGroup`][]
+    """
+
+    def create_task(
+        self,
+        coro: collections.abc.Coroutine[Any, Any, TaskReturnT],
+        *,
+        name: str | None = None,
+        context: contextvars.Context | None = None,
+    ) -> asyncio.Task[TaskReturnT]:
+        """Create a task.
+
+        Args:
+            coro: The coroutine to be executed.
+            name: The name of the task.
+            context: The context to be used for the task.
+
+        Returns:
+            The new task.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
 
 
 async def cancel_and_await(task: asyncio.Task[Any]) -> None:

--- a/src/frequenz/core/asyncio.py
+++ b/src/frequenz/core/asyncio.py
@@ -101,10 +101,10 @@ class Service(abc.ABC):
     implementation does not collect any results and re-raises all exceptions.
 
     Warning:
-        As services manage [`asyncio.Task`][] objects, a reference to them must be held
-        for as long as the service is expected to be running, otherwise its tasks will
-        be cancelled and the service will stop. For more information, please refer to
-        the [Python `asyncio`
+        As services manage [`asyncio.Task`][] objects, a reference to a running service
+        must be held for as long as the service is expected to be running. Otherwise, its
+        tasks will be cancelled and the service will stop. For more information, please
+        refer to the [Python `asyncio`
         documentation](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task).
 
     Example:

--- a/src/frequenz/core/asyncio.py
+++ b/src/frequenz/core/asyncio.py
@@ -59,8 +59,7 @@ class Service(abc.ABC):
     [`stop()`][frequenz.core.asyncio.Service.stop] method, as the base
     implementation does not collect any results and re-raises all exceptions.
 
-    !!! warning
-
+    Warning:
         As services manage [`asyncio.Task`][] objects, a reference to them must be held
         for as long as the service is expected to be running, otherwise its tasks will
         be cancelled and the service will stop. For more information, please refer to
@@ -130,8 +129,7 @@ class Service(abc.ABC):
         Users typically should not modify the tasks in the returned set and only use
         them for informational purposes.
 
-        !!! danger
-
+        Danger:
             Changing the returned tasks may lead to unexpected behavior, don't do it
             unless the class explicitly documents it is safe to do so.
         """

--- a/src/frequenz/core/asyncio.py
+++ b/src/frequenz/core/asyncio.py
@@ -120,16 +120,12 @@ class BackgroundService(abc.ABC):
 
     @property
     def unique_id(self) -> str:
-        """The unique ID of this background service.
-
-        Returns:
-            The unique ID of this background service.
-        """
+        """The unique ID of this background service."""
         return self._unique_id
 
     @property
     def tasks(self) -> collections.abc.Set[asyncio.Task[Any]]:
-        """Return the set of running tasks spawned by this background service.
+        """The set of running tasks spawned by this background service.
 
         Users typically should not modify the tasks in the returned set and only use
         them for informational purposes.
@@ -138,20 +134,14 @@ class BackgroundService(abc.ABC):
 
             Changing the returned tasks may lead to unexpected behavior, don't do it
             unless the class explicitly documents it is safe to do so.
-
-        Returns:
-            The set of running tasks spawned by this background service.
         """
         return self._tasks
 
     @property
     def is_running(self) -> bool:
-        """Return whether this background service is running.
+        """Whether this background service is running.
 
         A service is considered running when at least one task is running.
-
-        Returns:
-            Whether this background service is running.
         """
         return any(not task.done() for task in self._tasks)
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -9,7 +9,7 @@ from typing import Literal, assert_never
 import async_solipsism
 import pytest
 
-from frequenz.core.asyncio import Service
+from frequenz.core.asyncio import Service, TaskCreator
 
 
 # This method replaces the event loop for all tests in the file.
@@ -152,3 +152,18 @@ async def test_async_context_manager() -> None:
         assert fake_service.is_running is True
 
     assert fake_service.is_running is False
+
+
+def test_task_creator_asyncio() -> None:
+    """Test that the asyncio module is a TaskCreator."""
+    assert isinstance(asyncio, TaskCreator)
+
+
+async def test_task_creator_loop() -> None:
+    """Test that the asyncio event loop is a TaskCreator."""
+    assert isinstance(asyncio.get_event_loop(), TaskCreator)
+
+
+def test_task_creator_task_group() -> None:
+    """Test that the asyncio task group is a TaskCreator."""
+    assert isinstance(asyncio.TaskGroup(), TaskCreator)

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -110,9 +110,9 @@ async def test_start_stop() -> None:
     assert fake_service.is_running is False
 
 
-@pytest.mark.parametrize("method", ["await", "wait", "stop"])
+@pytest.mark.parametrize("method", ["await", "stop"])
 async def test_start_and_crash(
-    method: Literal["await"] | Literal["wait"] | Literal["stop"],
+    method: Literal["await"] | Literal["stop"],
 ) -> None:
     """Test a service reports when crashing."""
     exc = RuntimeError("error")
@@ -125,8 +125,6 @@ async def test_start_and_crash(
         match method:
             case "await":
                 await fake_service
-            case "wait":
-                await fake_service.wait()
             case "stop":
                 # Give the service some time to run and crash, otherwise stop() will
                 # cancel it before it has a chance to crash

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -9,7 +9,7 @@ from typing import Literal, assert_never
 import async_solipsism
 import pytest
 
-from frequenz.core.asyncio import Service, TaskCreator
+from frequenz.core.asyncio import ServiceBase, TaskCreator
 
 
 # This method replaces the event loop for all tests in the file.
@@ -19,7 +19,7 @@ def event_loop_policy() -> async_solipsism.EventLoopPolicy:
     return async_solipsism.EventLoopPolicy()
 
 
-class FakeService(Service):
+class FakeService(ServiceBase):
     """A service that does nothing."""
 
     def __init__(

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -9,7 +9,7 @@ from typing import Literal, assert_never
 import async_solipsism
 import pytest
 
-from frequenz.core.asyncio import BackgroundService
+from frequenz.core.asyncio import Service
 
 
 # This method replaces the event loop for all tests in the file.
@@ -19,8 +19,8 @@ def event_loop_policy() -> async_solipsism.EventLoopPolicy:
     return async_solipsism.EventLoopPolicy()
 
 
-class FakeService(BackgroundService):
-    """A background service that does nothing."""
+class FakeService(Service):
+    """A service that does nothing."""
 
     def __init__(
         self,
@@ -47,7 +47,7 @@ class FakeService(BackgroundService):
 
 
 async def test_construction_defaults() -> None:
-    """Test the construction of a background service with default arguments."""
+    """Test the construction of a service with default arguments."""
     fake_service = FakeService()
     assert fake_service.unique_id == hex(id(fake_service))[2:]
     assert fake_service.tasks == set()
@@ -60,7 +60,7 @@ async def test_construction_defaults() -> None:
 
 
 async def test_construction_custom() -> None:
-    """Test the construction of a background service with a custom unique ID."""
+    """Test the construction of a service with a custom unique ID."""
     fake_service = FakeService(unique_id="test")
     assert fake_service.unique_id == "test"
     assert fake_service.tasks == set()
@@ -68,7 +68,7 @@ async def test_construction_custom() -> None:
 
 
 async def test_start_await() -> None:
-    """Test a background service starts and can be awaited."""
+    """Test a service starts and can be awaited."""
     fake_service = FakeService(unique_id="test")
     assert fake_service.unique_id == "test"
     assert fake_service.is_running is False
@@ -88,7 +88,7 @@ async def test_start_await() -> None:
 
 
 async def test_start_stop() -> None:
-    """Test a background service starts and stops correctly."""
+    """Test a service starts and stops correctly."""
     fake_service = FakeService(unique_id="test", sleep=2.0)
     assert fake_service.unique_id == "test"
     assert fake_service.is_running is False
@@ -114,7 +114,7 @@ async def test_start_stop() -> None:
 async def test_start_and_crash(
     method: Literal["await"] | Literal["wait"] | Literal["stop"],
 ) -> None:
-    """Test a background service reports when crashing."""
+    """Test a service reports when crashing."""
     exc = RuntimeError("error")
     fake_service = FakeService(unique_id="test", exc=exc)
     assert fake_service.unique_id == "test"
@@ -143,7 +143,7 @@ async def test_start_and_crash(
 
 
 async def test_async_context_manager() -> None:
-    """Test a background service works as an async context manager."""
+    """Test a service works as an async context manager."""
     async with FakeService(unique_id="test", sleep=1.0) as fake_service:
         assert fake_service.is_running is True
         # Is a no-op if the service is running


### PR DESCRIPTION
The name `BackgroundService` is a bit too verbose now in the context of an asyncio library. Services are usually already understood as running in the background, so the `Background` prefix is redundant and makes the class name too long.

The `Service` class is made an abstract base class intended for end users that just want to use services, and a new `ServiceBase` class is added for developers that want to implement services. This way, the documentation can be separated between the two use cases and the `Service` class can be used as a generic type for services. We also avoid leaking implementation details to services users.

The `ServiceBase` class also have a new method `create_task` that is used to create tasks in the service, and a new `TaskCreator` protocol is added to allow overriding how tasks are created (for example, using a custom `loop` or a `TaskGroup`). `create_task` automatically adds the task to the internal set, so hopefully users won't forget so easily to register tasks.

The `create_task` method also have a new `log_exceptions` parameter that allows to log exceptions raised by tasks. This is useful because services tasks are supposed to run forever, and there are no many opportunities to await for their completion appropriately and handle the failure. With this at least we make sure we will get a log message when a task raises an exception, so we can at least know what happened and they just silently disappear.

Fixes #8, improves #9.