### PR TITLE
Improve documentation of `disable_init` decorator

### DIFF
--- a/src/frequenz/core/typing.py
+++ b/src/frequenz/core/typing.py
@@ -43,7 +43,8 @@ def disable_init(
     as the class is parsed by the Python interpreter. It will also raise a `TypeError`
     when the `__init__` method is called.
 
-    To create an instance you must provide a factory method, using `__new__`.
+    To create an instance you must provide a factory method, using `__new__` to create
+    the instance and calling `super().__init__(self)` explicitly to initialize it.
 
     Warning:
         This decorator will use a custom metaclass to disable the `__init__` constructor
@@ -64,6 +65,7 @@ def disable_init(
             @classmethod
             def new(cls, value: int = 1) -> Self:
                 self = cls.__new__(cls)
+                super().__init__(self)
                 self.value = value
                 return self
 
@@ -100,7 +102,9 @@ def disable_init(
         class MyClass:
             @classmethod
             def new(cls) -> Self:
-                return cls.__new__(cls)
+                self = cls.__new__(cls)
+                super().__init__(self)
+                return self
 
         try:
             instance = MyClass()


### PR DESCRIPTION
The `disable_init` decorator documentation was improved to clarify that the created instance must be explicitly initialized using `super().__init__(self)`.
