### PR TITLE
Log instead of warn when registering an ID prefix that already exists

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-* `BaseId` will now warn instead of raising an exception when a duplicate prefix is detected. This is to fix [a problem with code examples](https://github.com/frequenz-floss/frequenz-repo-config-python/issues/421) being tested using sybil and the class being imported multiple times, which caused the exception to be raised.
+* `BaseId` will now log instead of raising a warning when a duplicate prefix is detected. This is to fix [a problem with code examples](https://github.com/frequenz-floss/frequenz-repo-config-python/issues/421) being tested using sybil and the class being imported multiple times, which caused the exception to be raised. We first tried to use `warn()` but that complicated the building process for all downstream projects, requiring them to add an exception for exactly this warning.

--- a/src/frequenz/core/id.py
+++ b/src/frequenz/core/id.py
@@ -62,8 +62,10 @@ Example: Creating an ID type with a non-standard name
 '''
 
 
+import logging
 from typing import Any, ClassVar, Self, cast
-from warnings import warn
+
+_logger = logging.getLogger(__name__)
 
 
 class BaseId:
@@ -114,10 +116,9 @@ class BaseId:
         if str_prefix in BaseId._registered_prefixes:
             # We want to raise an exception here, but currently can't due to
             # https://github.com/frequenz-floss/frequenz-repo-config-python/issues/421
-            warn(
-                f"Prefix '{str_prefix}' is already registered. "
-                "ID prefixes must be unique.",
-                stacklevel=2,
+            _logger.warning(
+                "Prefix '%s' is already registered. ID prefixes must be unique.",
+                str_prefix,
             )
         BaseId._registered_prefixes.add(str_prefix)
 

--- a/tests/test_id.py
+++ b/tests/test_id.py
@@ -34,16 +34,6 @@ def test_use_a_subclass() -> None:
         BaseId(42)
 
 
-def test_warn_non_unique_prefix() -> None:
-    """Test that using a non-unique prefix raises a warning."""
-    with pytest.warns(UserWarning, match="Prefix 'TEST_ID' is already registered"):
-
-        class _TestDuplicateId(BaseId, str_prefix="TEST_ID"):
-            """A duplicate test ID class with the same prefix as _TestId."""
-
-        _TestDuplicateId(1)
-
-
 def test_negative_raises() -> None:
     """Test that creating a negative ID raises ValueError."""
     with pytest.raises(ValueError, match="_TestId can't be negative"):


### PR DESCRIPTION
From https://github.com/frequenz-floss/frequenz-client-dispatch-python/pull/181/files#r2154829282
