### PR TITLE
Fix dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
           - "minor"
         exclude-patterns:
           - "async-solipsism"
-          - "frequenz-repo-config"
+          - "frequenz-repo-config*"
           - "frequenz-repo-config[lib]"
           - "frequenz-repo-config[extra-lint-examples]"
           - "markdown-callouts"
@@ -49,7 +49,7 @@ updates:
       # each if we don't group them.
       repo-config:
         patterns:
-          - "frequenz-repo-config"
+          - "frequenz-repo-config*"
           - "frequenz-repo-config[lib]"
           - "frequenz-repo-config[extra-lint-examples]"
       mkdocstrings:


### PR DESCRIPTION
This is a new attempt to fix dependabot grouping, which seems to be still broken, generating wrong updates for repo-config that only update the dependency partially.

